### PR TITLE
Set framework deployment target to 9.0 (previously 11.3)

### DIFF
--- a/Example/PryntTrimmerView.xcodeproj/project.pbxproj
+++ b/Example/PryntTrimmerView.xcodeproj/project.pbxproj
@@ -778,7 +778,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = ../PryntTrimmerView/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.prynt.PryntTrimmerView;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -811,7 +811,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = ../PryntTrimmerView/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.prynt.PryntTrimmerView;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";


### PR DESCRIPTION
This should fix the failing Carthage build if your project supports iOS versions below 11.3 

```
module file's minimum deployment target is ios11.3 v11.3: /Users/sacha/Desktop/testPicker/Carthage/Checkouts/YPImagePicker/Carthage/Build/iOS/PryntTrimmerView.framework/Modules/PryntTrimmerView.swiftmodule/arm64.swiftmodule
import PryntTrimmerView
```