### PR TITLE
Fix typo in parameter name in AssetVideoScrollView

### DIFF
--- a/Sources/PryntTrimmerView/Parents/AssetVideoScrollView.swift
+++ b/Sources/PryntTrimmerView/Parents/AssetVideoScrollView.swift
@@ -64,7 +64,7 @@ class AssetVideoScrollView: UIScrollView {
         let thumbnailCount = Int(ceil(newContentSize.width / thumbnailSize.width))
         addThumbnailViews(thumbnailCount, size: thumbnailSize)
         let timesForThumbnail = getThumbnailTimes(for: asset, numberOfThumbnails: thumbnailCount)
-        generateImages(for: asset, at: timesForThumbnail, with: thumbnailSize, visibleThumnails: visibleThumbnailsCount)
+        generateImages(for: asset, at: timesForThumbnail, with: thumbnailSize, visibleThumbnails: visibleThumbnailsCount)
     }
 
     private func getThumbnailFrameSize(from asset: AVAsset) -> CGSize? {
@@ -126,7 +126,7 @@ class AssetVideoScrollView: UIScrollView {
         return timesForThumbnails
     }
 
-    private func generateImages(for asset: AVAsset, at times: [NSValue], with maximumSize: CGSize, visibleThumnails: Int) {
+    private func generateImages(for asset: AVAsset, at times: [NSValue], with maximumSize: CGSize, visibleThumbnails: Int) {
         generator = AVAssetImageGenerator(asset: asset)
         generator?.appliesPreferredTrackTransform = true
 
@@ -139,7 +139,7 @@ class AssetVideoScrollView: UIScrollView {
                 DispatchQueue.main.async(execute: { [weak self] () -> Void in
 
                     if count == 0 {
-                        self?.displayFirstImage(cgimage, visibleThumbnails: visibleThumnails)
+                        self?.displayFirstImage(cgimage, visibleThumbnails: visibleThumbnails)
                     }
                     self?.displayImage(cgimage, at: count)
                     count += 1


### PR DESCRIPTION
Hello, I'm a university student in South Korea aspiring to become an iOS developer. While studying independently, I discovered a typo and decided to challenge myself by making my first contribution to open source through this PR. As I'm still learning and developing my skills, there may be areas where I lack expertise. If there are any issues with my PR, I would greatly appreciate your feedback and guidance.

---

## Description
This Pull Request fixes a typo in the parameter name of the generateImages(for:at:with:visibleThumnails:) method in the AssetVideoScrollView class.

## Changes
Renamed the parameter visibleThumnails to visibleThumbnails for improved clarity and consistency.
This change does not affect functionality but enhances code readability.